### PR TITLE
Drop -u flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Removed
+- Remove undefined (`-u`).
+
 ## 0.1.0 - 2023-01-29
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -110,11 +110,10 @@ typically in a format that is easier to specify on the command line.
     -f  # false
     ```
 
-- `null` and `undefined` are expressed as `-n` and `-u` respectively.
+- `null` is expressed as `-n`.
 
     ```bash
     -n  # null
-    -u  # undefined
     ```
 
 - Arrays of values are expressed by wrapping the with `[`, `]`.

--- a/decode.go
+++ b/decode.go
@@ -422,7 +422,7 @@ type anyDecoder struct {
 func (d *anyDecoder) Decode(ctx decodeCtx, t value) (reflect.Value, error) {
 	v := reflect.New(d.t).Elem()
 	switch t.t {
-	case nullType, undefinedType:
+	case nullType:
 		v.Set(reflect.Zero(d.t))
 	case boolType:
 		v.Set(reflect.ValueOf(t.b))

--- a/parse.go
+++ b/parse.go
@@ -127,8 +127,6 @@ func (p *parser) valueFrom(arg string) (value, error) {
 		return boolValue(arg == "-t"), nil
 	case "-n":
 		return _null, nil
-	case "-u":
-		return _undefined, nil
 	case "--":
 		v, ok := p.next()
 		if !ok {

--- a/parse_test.go
+++ b/parse_test.go
@@ -223,10 +223,6 @@ func TestParseAny(t *testing.T) {
 			want: nil,
 		},
 		{
-			give: []string{"-u"},
-			want: nil,
-		},
-		{
 			give: []string{"[", "]"},
 			want: array{},
 		},

--- a/value.go
+++ b/value.go
@@ -7,14 +7,13 @@ import (
 type valueType int
 
 const (
-	invalidType   valueType = iota
-	nullType                // -n
-	undefinedType           // -u
-	boolType                // -t or -f
-	stringType              // explicitly a string
-	scalarType              // string, int, float, complex
-	arrayType               // [], [ ... ]
-	objectType              // [--], [ --k v ... ]
+	invalidType valueType = iota
+	nullType              // -n
+	boolType              // -t or -f
+	stringType            // explicitly a string
+	scalarType            // string, int, float, complex
+	arrayType             // [], [ ... ]
+	objectType            // [--], [ --k v ... ]
 )
 
 func (t valueType) String() string {
@@ -23,8 +22,6 @@ func (t valueType) String() string {
 		return "invalid"
 	case nullType:
 		return "null"
-	case undefinedType:
-		return "undefined"
 	case boolType:
 		return "bool"
 	case stringType:
@@ -60,9 +57,8 @@ type value struct {
 }
 
 var (
-	_invalid   = value{t: invalidType}
-	_null      = value{t: nullType}
-	_undefined = value{t: undefinedType}
+	_invalid = value{t: invalidType}
+	_null    = value{t: nullType}
 )
 
 func stringValue(s string) value {

--- a/value_test.go
+++ b/value_test.go
@@ -16,7 +16,6 @@ func TestValueType_String(t *testing.T) {
 	}{
 		{invalidType, "invalid"},
 		{nullType, "null"},
-		{undefinedType, "undefined"},
 		{boolType, "bool"},
 		{stringType, "string"},
 		{scalarType, "scalar"},


### PR DESCRIPTION
'undefined' was not intended to be supported in the format.
This was an oversight in the reference implementation.

Delete the flag and all references to it.

Resolves #3