### PR TITLE
Add ParseObject function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `ParseObject` function for cases where `[`,`]` should be assumed.
+
 ### Changed
 - Rename bundled CLI to 'shon'.
 

--- a/options.go
+++ b/options.go
@@ -6,7 +6,8 @@ import "fmt"
 type ParseOption interface{ applyParseOption(*parseOptions) }
 
 type parseOptions struct {
-	useNumber bool
+	useNumber      bool
+	implicitObject bool
 }
 
 func buildParseOptions(opts ...ParseOption) parseOptions {
@@ -36,4 +37,29 @@ func (o useNumberOption) String() string {
 
 func (o useNumberOption) applyParseOption(opts *parseOptions) {
 	opts.useNumber = bool(o)
+}
+
+// implicitObject specifies that Parse should assume it's inside an object
+// at the top level.
+// With this,
+//
+//	foo --bar baz --qux -t
+//
+// Is treated as if it was:
+//
+//	foo [ --bar baz --qux -t ]
+//
+// This option is not public -- users should use the ParseObject function.
+func implicitObject(b bool) ParseOption {
+	return implicitObjectOption(b)
+}
+
+type implicitObjectOption bool
+
+func (o implicitObjectOption) String() string {
+	return fmt.Sprintf("implicitObject(%v)", bool(o))
+}
+
+func (o implicitObjectOption) applyParseOption(opts *parseOptions) {
+	opts.implicitObject = bool(o)
 }


### PR DESCRIPTION
Adds a ParseObject that assumes `[`,`]` around the input.
This makes it usable for CLI-style use cases.

Resolves #2