### PR TITLE
ci(lint): Use golangci-lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/tools"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod"
     directory: "/playground"
     schedule:
       interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,34 +8,41 @@ on:
 
 jobs:
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      name: Check out repository
+    - uses: actions/setup-go@v4
+      name: Set up Go
+      with:
+        go-version: 1.20.x
+        cache: false
+    - uses: golangci/golangci-lint-action@v3
+      name: Install golangci-lint
+      with:
+        version: latest
+        args: --version
+    - run: make lint
+      name: Lint
+
   build:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         go: ["1.19.x", "1.20.x"]
-        include:
-        - go: 1.20.x
-          latest: true
 
     steps:
     - uses: actions/checkout@v3
-
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go }}
         cache: true
-
     - name: Download dependencies
       run: go mod download
-
-    - name: Lint
-      if: matrix.latest
-      run: make lint
-
     - name: Test
       run: make cover
-
     - name: Upload coverage
       uses: codecov/codecov-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+issues:
+  # Print all issues reported by all linters.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  # Don't ignore some of the issues that golangci-lint considers okay.
+  exclude-use-default: false
+
+output:
+  # Make output more digestible with quickfix in vim.
+  sort-results: true
+  print-issued-lines: false
+
+linters:
+  enable:
+    - gofumpt
+    - nolintlint
+    - paralleltest
+    - revive
+
+linter-settings:
+  govet:
+    enable:
+      - niliness
+      - reflectvaluecompare
+      - sortslice
+      - unusedwrite

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,38 @@
 SHELL = /bin/bash
 
+PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 # Setting GOBIN and PATH ensures two things:
 # - All 'go install' commands we run
 #   only affect the current directory.
 # - All installed tools are available on PATH
 #   for commands like go generate.
-export GOBIN ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/bin
+export GOBIN = $(PROJECT_ROOT)/bin
 export PATH := $(GOBIN):$(PATH)
 
-MODULES ?= . ./tools
-TEST_FLAGS ?= -v
-
-STATICCHECK = bin/staticcheck
-REVIVE = bin/revive
-
-# All known Go files.
-GO_FILES = $(shell find . \
-	   -path '*/.*' -prune -o \
-	   '(' -type f -a -name '*.go' ')' -print)
-
-# All known go.mod and go.sum files.
-GO_MOD_FILES = \
-	$(patsubst %,%/go.mod,$(MODULES)) \
-	$(patsubst %,%/go.sum,$(MODULES))
-
+TEST_FLAGS ?= -v -race
 
 .PHONY: all
 all: lint test
 
 .PHONY: lint
-lint: fmtcheck tidycheck staticcheck revive
+lint: golangci-lint tidy-lint
+
+.PHONY: golangci-lint
+golangci-lint:
+	@echo "[lint] Checking golangci-lint"
+	@golangci-lint run
+
+.PHONY: tidy
+tidy:
+	go mod tidy
+
+.PHONY: tidy-lint
+tidy-lint:
+	@echo "[lint] Checking go mod tidy"
+	@go mod tidy && \
+		git diff --exit-code -- go.mod go.sum || \
+		(echo "[$(mod)] go mod tidy changed files" && false)
 
 .PHONY: test
 test:
@@ -39,43 +42,3 @@ test:
 cover:
 	go test $(TEST_FLAGS) -coverprofile=cover.out -coverpkg=./... ./...
 	go tool cover -html=cover.out -o cover.html
-
-.PHONY: fmt
-fmt:
-	gofmt -w -s $(GO_FILES)
-
-.PHONY: tidy
-tidy:
-	$(foreach dir,$(MODULES),(cd $(dir) && go mod tidy) &&) true
-
-.PHONY: fmtcheck
-fmtcheck:
-	@DIFF=$$(gofmt -d -s $(GO_FILES)); \
-	if [[ -n "$$DIFF" ]]; then \
-		echo "gofmt would cause changes:"; \
-		echo "$$DIFF"; \
-		false; \
-	fi
-
-.PHONY: staticcheck
-staticcheck: $(STATICCHECK)
-	staticcheck ./...
-
-.PHONY: revive
-revive: $(REVIVE)
-	revive -set_exit_status ./...
-
-.PHONY: tidycheck
-tidycheck:
-	make tidy
-	@if ! git diff --quiet $(GO_MOD_FILES); then \
-		echo "go mod tidy changed files:" && \
-		git status --porcelain $(GO_MOD_FILES) && \
-		false; \
-	fi
-
-$(STATICCHECK): tools/go.mod
-	cd tools && go install honnef.co/go/tools/cmd/staticcheck
-
-$(REVIVE): tools/go.mod
-	cd tools && go install github.com/mgechev/revive


### PR DESCRIPTION
Switch to golangci-lint to manage linters
instead of hand-managing them in the Makefile.
